### PR TITLE
limit wait time for -1 socket timeouts and increase polling interval

### DIFF
--- a/src/main/java/org/zeromq/jms/protocol/AbstractZmqGateway.java
+++ b/src/main/java/org/zeromq/jms/protocol/AbstractZmqGateway.java
@@ -179,14 +179,16 @@ public abstract class AbstractZmqGateway implements ZmqGateway {
      * @param  onStatus  the set of status you are waiting for
      * @return           return true when the status have been met
      */
-    protected boolean waitOnStatus(final long millis, final EnumSet<ZmqSocketStatus> onStatus) {
+    protected boolean waitOnStatus(long millis, final EnumSet<ZmqSocketStatus> onStatus) {
         final Stopwatch stopwatch = new Stopwatch();
 
         long waitTime = SOCKET_WAIT_MILLI_SECOND;
 
         if (millis < 0) {
-            waitTime = SOCKET_STATUS_TIMEOUT_MILLI_SECOND;
-        } else if (millis < waitTime) {
+            millis = SOCKET_STATUS_TIMEOUT_MILLI_SECOND;
+        }
+
+        if (millis < waitTime) {
             waitTime = millis / 2;
         }
         boolean success = false;


### PR DESCRIPTION
This patch increases the polling frequency to SOCKET_WAIT_MILLI_SECOND even when
passing -1 as the timeout (which is done in all default cases).
As a side effect, waitOnStatus with a -1 timeout does not wait infinitely long
anymore but rather waits for a maximum of SOCKET_STATUS_TIMEOUT_MILLI_SECOND which
is what the name of the constant suggests.

Fixes #9